### PR TITLE
Escape currency dollars in markdown rendering

### DIFF
--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -14,6 +14,10 @@ export interface MarkdownProps {
   components: Partial<Components>;
 }
 
+function escapeCurrencyDollarSigns(text: string): string {
+  return text.replace(/\$(?=\d)/g, "\\$");
+}
+
 function parseMarkdownIntoBlocks(markdown: string): string[] {
   const tokens = marked.lexer(markdown);
   return tokens.map((token) => token.raw);
@@ -33,7 +37,7 @@ const MemoizedMarkdownBlock = memo(
         rehypePlugins={[rehypeKatex]}
         components={components}
       >
-        {content}
+        {escapeCurrencyDollarSigns(content)}
       </ReactMarkdown>
     );
   },


### PR DESCRIPTION
## Summary
- Escape dollar signs that precede digits before passing markdown content to `ReactMarkdown`.
- Prevent currency values like `$10` from being parsed as math in rendered markdown.
- Keep the change scoped to the markdown block rendering path in `packages/ui`.

## Testing
- Not run (PR content only).
- Verified the patch updates markdown rendering to escape currency-formatted dollar signs.