### PR TITLE
Switch workspace typechecks to tsgo

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,7 +9,7 @@
     "dev:app": "next dev --turbo",
     "start": "next start",
     "lint": "eslint --flag unstable_native_nodejs_ts_config",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "format": "prettier --check . --ignore-path ../../.gitignore --ignore-path .prettierignore",
     "format:fix": "prettier --write . --ignore-path ../../.gitignore --ignore-path .prettierignore",
     "clean": "git clean -xdf node_modules .next .source .turbo .cache",

--- a/apps/docs/src/env.d.ts
+++ b/apps/docs/src/env.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,7 @@
     "start": "node .output/server/index.mjs",
     "preview": "pnpm with-env vite preview",
     "lint": "eslint --flag unstable_native_nodejs_ts_config",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "format": "prettier --check . --ignore-path ../../.gitignore --ignore-path .prettierignore",
     "format:fix": "prettier --write . --ignore-path ../../.gitignore --ignore-path .prettierignore",
     "clean": "git clean -xdf node_modules .cache .tanstack .turbo .output",

--- a/apps/xr/package.json
+++ b/apps/xr/package.json
@@ -10,7 +10,7 @@
     "start": "node .output/server/index.mjs",
     "preview": "pnpm with-env vite preview",
     "lint": "eslint --flag unstable_native_nodejs_ts_config",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "format": "prettier --check . --ignore-path ../../.gitignore --ignore-path .prettierignore",
     "format:fix": "prettier --write . --ignore-path ../../.gitignore --ignore-path .prettierignore",
     "clean": "git clean -xdf node_modules .cache .tanstack .turbo",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@acme/prettier-config": "workspace:*",
     "@effect/language-service": "0.85.1",
     "@turbo/gen": "2.8.17",
+    "@typescript/native-preview": "catalog:",
     "dotenv-cli": "10.0.0",
     "portless": "^0.12.0",
     "prettier": "catalog:",

--- a/packages/app-config/package.json
+++ b/packages/app-config/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "format:fix": "prettier --write . --ignore-path ../../.gitignore",
     "lint": "eslint --flag unstable_native_nodejs_ts_config",
-    "typecheck": "tsc"
+    "typecheck": "tsgo --noEmit"
   },
   "devDependencies": {
     "@acme/eslint-config": "workspace:*",

--- a/packages/db/.gitignore
+++ b/packages/db/.gitignore
@@ -1,0 +1,2 @@
+
+.env.local

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -39,7 +39,7 @@
     "format": "prettier --check . --ignore-path ../../.gitignore --ignore-path .prettierignore",
     "fomat:fix": "prettier --write . --ignore-path ../../.gitignore --ignore-path .prettierignore",
     "lint": "eslint --flag unstable_native_nodejs_ts_config",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "setup": "convex dev --until-success",
     "logs": "convex logs"
   },

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -28,7 +28,7 @@
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "format:fix": "prettier --write . --ignore-path ../../.gitignore",
     "lint": "eslint --flag unstable_native_nodejs_ts_config",
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false"
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@acme/db": "workspace:*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,7 +37,7 @@
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "format:fix": "prettier --write . --ignore-path ../../.gitignore",
     "lint": "eslint --flag unstable_native_nodejs_ts_config",
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false"
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.1.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ catalogs:
     '@types/node':
       specifier: ^24
       version: 24.12.2
+    '@typescript/native-preview':
+      specifier: 7.0.0-dev.20260512.1
+      version: 7.0.0-dev.20260512.1
     '@vitejs/plugin-react':
       specifier: 5.1.0
       version: 5.1.0
@@ -182,6 +185,9 @@ importers:
       '@turbo/gen':
         specifier: 2.8.17
         version: 2.8.17(@types/node@24.12.2)
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260512.1
       dotenv-cli:
         specifier: 10.0.0
         version: 10.0.0
@@ -4209,6 +4215,53 @@ packages:
   '@typescript-eslint/visitor-keys@8.58.1':
     resolution: {integrity: sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260512.1':
+    resolution: {integrity: sha512-l9AJi/TIVMPx5R1c7fxZCSA7eUaHeA0C9Mxdxx/oQJo1K/GtbI3mzYe/SiKNltko1KSdKUmWVhPwxTOS289REg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260512.1':
+    resolution: {integrity: sha512-oABZLQrfB8JN2Ct2CiLK5PyE28Em3sIJlZsAMD45/A2ymtIaa5826dwv8vapE5Wjp54ao0LXxCSuKFm1A8zzCQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260512.1':
+    resolution: {integrity: sha512-xvbwzpTe+5N6bnBI/t9n4zsGzXxz3V6rVbvDUoJmRLfav5fz+ck0QDkGQGUPrQEEIp0KEzQvx7c+AEZnzdvTQA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260512.1':
+    resolution: {integrity: sha512-0Hs1Gqa/t9cthoPdqHud1pFGUr9DgJivBTjwquTUh8jt/6PI2bQxoMNZLiN/bhqeDFDTzdxoMBfCaytsTMcXqw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260512.1':
+    resolution: {integrity: sha512-qr5h6FPo74bN/U+EwRuayBhUbxaji8xzFbIbhMOA2oYSc/qozp5ia2g1+9xGw67MXxPPw/IPT+UGvrNK7K1NeQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260512.1':
+    resolution: {integrity: sha512-meNWxhNEfaqos2U0JXvfxWvy4JWrKE9fZepCndDZi+t04X+AIiLYp5s6crWnKP67nzVAzMNgTAc8mu8CnGM+/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260512.1':
+    resolution: {integrity: sha512-Hp6vBnxJSKEEAVWgIoWMmfqkZXCdkhm6XTivrwgRzBwWfiTVe2ZyZ7byWegIKeNnBbffg/K2KvoM8JAHl059GQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260512.1':
+    resolution: {integrity: sha512-KIzYPGuxZnyiiYkYrozDT94Af2nwbdLXoY1cgGY66RRa9HSEw13RH9WHg8wA8fZhT4wYzF5uF7WY3hz0QhaxGg==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -10182,6 +10235,37 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.58.1
       eslint-visitor-keys: 5.0.1
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260512.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260512.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260512.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260512.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260512.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260512.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260512.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260512.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260512.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260512.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260512.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260512.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260512.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260512.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260512.1
 
   '@ungap/structured-clone@1.3.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,6 +48,7 @@ catalog:
   tailwindcss: ^4.1.16
   tailwind-merge: ^3.3.1
   tw-animate-css: ^1.4.0
+  "@typescript/native-preview": 7.0.0-dev.20260512.1
   typescript: ^5.9.3
   uploadthing: ^7.7.4
   vite: 7.3.1

--- a/tooling/eslint/package.json
+++ b/tooling/eslint/package.json
@@ -12,7 +12,7 @@
     "clean": "git clean -xdf .cache .turbo node_modules",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "format:fix": "prettier --write . --ignore-path ../../.gitignore",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@eslint/compat": "^1.4.0",

--- a/tooling/eslint/tsconfig.json
+++ b/tooling/eslint/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "@acme/tsconfig/base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
   "include": ["."],
   "exclude": ["node_modules"]
 }

--- a/tooling/prettier/package.json
+++ b/tooling/prettier/package.json
@@ -9,7 +9,7 @@
     "clean": "git clean -xdf .cache .turbo node_modules",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "format:fix": "prettier --write . --ignore-path ../../.gitignore",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.7.0",

--- a/tooling/tailwind/package.json
+++ b/tooling/tailwind/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "format:fix": "prettier --write . --ignore-path ../../.gitignore",
     "lint": "eslint --flag unstable_native_nodejs_ts_config",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@tailwindcss/postcss": "catalog:",

--- a/tooling/tailwind/tsconfig.json
+++ b/tooling/tailwind/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "@acme/tsconfig/base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
   "include": ["."],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- Replaced `tsc`-based typecheck scripts with `tsgo` across apps, packages, and tooling.
- Added `@typescript/native-preview` to the workspace catalog and root dependencies so `tsgo` is available consistently.
- Added Node type declarations to the ESLint and Tailwind tool configs, and added a CSS module declaration for the docs app.
- Added a `packages/db/.gitignore` entry for local `.env.local` files.

## Testing
- Not run locally.
- Expected validation commands: `pnpm run lint`
- Expected validation commands: `pnpm run typecheck`
- Expected formatting step after successful checks: `pnpm run format:fix`