### PR TITLE
Remove Upstash KV caching from DB search tools

### DIFF
--- a/apps/docs/content/docs/getting-started/fin.mdx
+++ b/apps/docs/content/docs/getting-started/fin.mdx
@@ -14,7 +14,6 @@ need various API keys from each of them. See [the environment variables section]
 - [Google](https://console.cloud.google.com/)
 - [Open Router](https://openrouter.ai/)
 - [Resend](https://resend.com/)
-- [Upstash](https://upstash.com/)
 - [UploadThing](https://uploadthing.com/)
 
 ## Running the app locally

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -58,7 +58,6 @@
     "@polar-sh/sdk": "catalog:",
     "@react-email/components": "^1.0.12",
     "@react-email/render": "^2.0.6",
-    "@upstash/redis": "^1.35.3",
     "ai": "catalog:",
     "convex": "catalog:",
     "convex-env": "^3.0.0",

--- a/packages/db/src/_generated/api.d.ts
+++ b/packages/db/src/_generated/api.d.ts
@@ -123,7 +123,6 @@ import type * as convex_helpers from "../convex_helpers.js";
 import type * as counter from "../counter.js";
 import type * as crons from "../crons.js";
 import type * as http from "../http.js";
-import type * as kv from "../kv.js";
 import type * as lib_date_time_utils from "../lib/date_time_utils.js";
 import type * as lib_utils from "../lib/utils.js";
 import type * as limiter from "../limiter.js";
@@ -262,7 +261,6 @@ declare const fullApi: ApiFromModules<{
   counter: typeof counter;
   crons: typeof crons;
   http: typeof http;
-  kv: typeof kv;
   "lib/date_time_utils": typeof lib_date_time_utils;
   "lib/utils": typeof lib_utils;
   limiter: typeof limiter;

--- a/packages/db/src/ai/tools/search/current_events.ts
+++ b/packages/db/src/ai/tools/search/current_events.ts
@@ -2,15 +2,9 @@ import { z } from "zod";
 
 import type { SearchReturnType } from "./schemas";
 import { createTool } from "../../../agent/tools";
-import { kv } from "../../../kv";
 import { getCurrentDateTime } from "../../../lib/date_time_utils";
 import { tryCatch } from "../../../lib/utils";
-import {
-  exaSearchAndContents,
-  formatCacheKey,
-  logSearchCost,
-} from "../tool_helpers";
-import { CachedSourceSchema } from "./schemas";
+import { exaSearchAndContents, logSearchCost } from "../tool_helpers";
 
 const NUM_RESULTS = 5;
 
@@ -46,20 +40,6 @@ export const currentEvents = createTool({
       ),
   }),
   execute: async (ctx, args): Promise<SearchReturnType> => {
-    // check cache
-    const cacheKey = formatCacheKey("current-events", [args.query]);
-    const cachedData = await kv.get(cacheKey);
-    const cachedSources = await CachedSourceSchema.safeParseAsync(cachedData);
-    if (cachedSources.success) {
-      return {
-        sources: cachedSources.data.sources,
-        currentDateTime: {
-          timezone: "America/New_York",
-          dateTime: getCurrentDateTime({ timezone: "America/New_York" }),
-        },
-      };
-    }
-
     const { data: response, error: responseError } = await tryCatch(
       exaSearchAndContents(args.query, {
         numResults: NUM_RESULTS,
@@ -86,15 +66,6 @@ export const currentEvents = createTool({
       favicon: result.favicon,
       image: result.image,
     }));
-
-    // write to cache
-    await kv.set(
-      cacheKey,
-      { sources },
-      {
-        ex: 60 * 10, // 10 minutes
-      },
-    );
 
     const dateTime = getCurrentDateTime({
       timezone: "America/New_York",

--- a/packages/db/src/ai/tools/search/postition_holder.ts
+++ b/packages/db/src/ai/tools/search/postition_holder.ts
@@ -2,15 +2,9 @@ import { z } from "zod";
 
 import type { SearchReturnType } from "./schemas";
 import { createTool } from "../../../agent/tools";
-import { kv } from "../../../kv";
 import { getCurrentDateTime } from "../../../lib/date_time_utils";
 import { tryCatch } from "../../../lib/utils";
-import {
-  exaSearchAndContents,
-  formatCacheKey,
-  logSearchCost,
-} from "../tool_helpers";
-import { CachedSourceSchema } from "./schemas";
+import { exaSearchAndContents, logSearchCost } from "../tool_helpers";
 
 const NUM_RESULTS = 5;
 const MAX_CHARACTERS = 3000;
@@ -59,23 +53,6 @@ export const positionHolder = createTool({
       ),
   }),
   execute: async (ctx, args): Promise<SearchReturnType> => {
-    // check cache
-    const cacheKey = formatCacheKey("position-holder", [
-      args.position,
-      args.group,
-    ]);
-    const cachedData = await kv.get(cacheKey);
-    const cachedResult = await CachedSourceSchema.safeParseAsync(cachedData);
-    if (cachedResult.success) {
-      return {
-        sources: cachedResult.data.sources,
-        currentDateTime: {
-          timezone: "America/New_York",
-          dateTime: getCurrentDateTime({ timezone: "America/New_York" }),
-        },
-      };
-    }
-
     const { data: response, error: responseError } = await tryCatch(
       exaSearchAndContents(args.query, {
         numResults: NUM_RESULTS,
@@ -101,15 +78,6 @@ export const positionHolder = createTool({
       favicon: result.favicon,
       image: result.image,
     }));
-
-    // write to cache
-    await kv.set(
-      cacheKey,
-      {
-        sources,
-      },
-      { ex: 60 * 60 }, // 1 hour
-    );
 
     const dateTime = getCurrentDateTime({
       timezone: "America/New_York",

--- a/packages/db/src/ai/tools/search/schemas.ts
+++ b/packages/db/src/ai/tools/search/schemas.ts
@@ -9,9 +9,6 @@ export const SourceSchema = z.object({
   favicon: z.string().optional().nullable(),
   image: z.string().optional().nullable(),
 });
-export const CachedSourceSchema = z.object({
-  sources: z.array(SourceSchema),
-});
 export type Source = z.infer<typeof SourceSchema>;
 
 export type SearchReturnType = {

--- a/packages/db/src/ai/tools/tool_helpers.ts
+++ b/packages/db/src/ai/tools/tool_helpers.ts
@@ -61,10 +61,3 @@ export async function logSearchCost(
     cost: totalCost,
   });
 }
-
-export function formatCacheKey(toolName: string, args: string[]) {
-  const formattedArgs = args.map((arg) =>
-    arg.replace(/[\s,]+/g, "-").toLowerCase(),
-  );
-  return `tool:${toolName}:${formattedArgs.join("_")}`;
-}

--- a/packages/db/src/ai/tools/weather.ts
+++ b/packages/db/src/ai/tools/weather.ts
@@ -3,9 +3,7 @@ import { z } from "zod";
 import { internal } from "../../_generated/api";
 import { createTool } from "../../agent/tools";
 import { env } from "../../convex.env";
-import { kv } from "../../kv";
 import { tryCatch } from "../../lib/utils";
-import { formatCacheKey } from "./tool_helpers";
 
 const weatherArgs = z.object({
   location: z
@@ -77,19 +75,6 @@ function buildWeatherUrl(
   }
 }
 
-function getCacheTtl(queryType: QueryType) {
-  switch (queryType) {
-    case "current-conditions":
-      return 60 * 10; // 10 minutes
-    case "daily-forecast":
-      return 60 * 60; // 1 hour
-    case "hourly-forecast":
-      return 60 * 10; // 10 minutes
-    case "last-24-hours":
-      return 60 * 10; // 10 minutes
-  }
-}
-
 async function getCoordinates(location: string) {
   const geocodingResponse = await fetch(
     `https://maps.googleapis.com/maps/api/geocode/json?address=${location}&key=${env.GOOGLE_API_KEY}`,
@@ -118,19 +103,6 @@ export const weather = createTool({
   `,
   inputSchema: weatherArgs,
   execute: async (ctx, args) => {
-    // check cache
-    const cacheKey = formatCacheKey("weather", [
-      args.location,
-      args.queryType,
-      args.days.toString(),
-      args.unitSystem,
-    ]);
-    const cachedWeather = await kv.get(cacheKey);
-    if (cachedWeather) {
-      return cachedWeather;
-    }
-
-    // get lat and long for location
     const { data: coordinates, error: coordinatesError } = await tryCatch(
       getCoordinates(args.location),
     );
@@ -155,10 +127,6 @@ export const weather = createTool({
       );
       return null;
     }
-
-    // write to cache
-    const ttl = getCacheTtl(args.queryType);
-    await kv.set(cacheKey, weatherData, { ex: ttl });
 
     // log usage
     if (ctx.userId) {

--- a/packages/db/src/convex.env.ts
+++ b/packages/db/src/convex.env.ts
@@ -5,13 +5,11 @@ import {
   polar,
   resend,
   uploadthing,
-  upstash,
 } from "convex-env/presets";
 import { v } from "convex/values";
 
 export const env = createEnv({
   ...environment,
-  ...upstash,
   ...uploadthing,
   ...resend,
   ...polar,

--- a/packages/db/src/kv.ts
+++ b/packages/db/src/kv.ts
@@ -1,8 +1,0 @@
-import { Redis } from "@upstash/redis";
-
-import { env } from "./convex.env";
-
-export const kv = new Redis({
-  url: env.UPSTASH_REDIS_REST_URL,
-  token: env.UPSTASH_REDIS_REST_TOKEN,
-});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -704,9 +704,6 @@ importers:
       '@react-email/render':
         specifier: ^2.0.6
         version: 2.0.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@upstash/redis':
-        specifier: ^1.35.3
-        version: 1.37.0
       ai:
         specifier: 'catalog:'
         version: 6.0.158(zod@3.25.76)
@@ -10289,6 +10286,7 @@ snapshots:
   '@upstash/redis@1.37.0':
     dependencies:
       uncrypto: 0.1.3
+    optional: true
 
   '@vercel/oidc@3.1.0': {}
 
@@ -13778,7 +13776,8 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  uncrypto@0.1.3: {}
+  uncrypto@0.1.3:
+    optional: true
 
   undici-types@7.16.0: {}
 


### PR DESCRIPTION
## Summary
- Removed Upstash KV caching from the DB search and weather tools.
- Deleted the `kv` helper, cache key utilities, and cache-aware schemas that were only used for those flows.
- Cleaned up related package, env, lockfile, and docs references to Upstash.

## Testing
- Not run (not requested).
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:fix`