### PR TITLE
Improve dialog forms and add newsletter preferences

### DIFF
--- a/apps/web/src/components/alert.tsx
+++ b/apps/web/src/components/alert.tsx
@@ -65,6 +65,11 @@ export function CustomAlert({
                 className="mt-2"
                 value={typeToConfirmValue}
                 onChange={(e) => setTypeToConfirmValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !disabled) {
+                    onConfirm();
+                  }
+                }}
               />
             </AlertDialogDescription>
           )}

--- a/apps/web/src/features/library/components/library-rename-modal.tsx
+++ b/apps/web/src/features/library/components/library-rename-modal.tsx
@@ -3,16 +3,16 @@ import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import { useFileMutations, useLibraryStore } from "@acme/features/library";
+import { Button } from "@acme/ui/button";
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@acme/ui/alert-dialog";
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@acme/ui/dialog";
 import { Input } from "@acme/ui/input";
 
 export function LibraryRenameModal() {
@@ -38,44 +38,48 @@ export function LibraryRenameModal() {
   });
 
   return (
-    <AlertDialog
+    <Dialog
       open={libraryRenameModalOpen}
       onOpenChange={setLibraryRenameModalOpen}
     >
-      <AlertDialogContent
+      <DialogContent
+        showCloseButton={false}
         onOpenAutoFocus={(e) => {
           e.preventDefault();
           inputRef.current?.focus();
         }}
       >
-        <AlertDialogHeader>
-          <AlertDialogTitle>Rename File</AlertDialogTitle>
-        </AlertDialogHeader>
-        <AlertDialogDescription className="flex flex-col gap-2">
-          <span className="text-muted-foreground">
-            Enter a new name for the file.
-          </span>
-          <Input
-            ref={inputRef}
-            value={newFileName}
-            onChange={(e) => setNewFileName(e.target.value)}
-            placeholder="Enter a new name..."
-          />
-        </AlertDialogDescription>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={() => {
-              if (!selectedFile) return;
-              renameFile({ id: selectedFile.id, name: newFileName });
-              setLibraryRenameModalOpen(false);
-              setNewFileName("");
-            }}
-          >
-            Rename
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (!selectedFile) return;
+            renameFile({ id: selectedFile.id, name: newFileName });
+            setLibraryRenameModalOpen(false);
+            setNewFileName("");
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>Rename File</DialogTitle>
+          </DialogHeader>
+          <DialogDescription className="flex flex-col gap-2 py-4">
+            <span className="text-muted-foreground">
+              Enter a new name for the file.
+            </span>
+            <Input
+              ref={inputRef}
+              value={newFileName}
+              onChange={(e) => setNewFileName(e.target.value)}
+              placeholder="Enter a new name..."
+            />
+          </DialogDescription>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline">Cancel</Button>
+            </DialogClose>
+            <Button type="submit">Rename</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/src/features/thread/components/thread-rename-modal.tsx
+++ b/apps/web/src/features/thread/components/thread-rename-modal.tsx
@@ -3,7 +3,16 @@ import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import { useThreadMutations, useThreadStore } from "@acme/features/thread";
-import * as Alert from "@acme/ui/alert-dialog";
+import { Button } from "@acme/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@acme/ui/dialog";
 import { Input } from "@acme/ui/input";
 
 export function ThreadRenameModal() {
@@ -26,7 +35,7 @@ export function ThreadRenameModal() {
   const inputRef = useRef<HTMLInputElement>(null);
 
   return (
-    <Alert.AlertDialog
+    <Dialog
       open={renameModalOpen}
       onOpenChange={(open) => {
         if (open) {
@@ -37,43 +46,47 @@ export function ThreadRenameModal() {
         }
       }}
     >
-      <Alert.AlertDialogContent
+      <DialogContent
+        showCloseButton={false}
         onOpenAutoFocus={(e) => {
           e.preventDefault();
           inputRef.current?.focus();
         }}
       >
-        <Alert.AlertDialogHeader>
-          <Alert.AlertDialogTitle>Rename Thread</Alert.AlertDialogTitle>
-        </Alert.AlertDialogHeader>
-        <Alert.AlertDialogDescription className="flex flex-col gap-2">
-          <span className="text-muted-foreground">
-            Enter a new name for the thread.
-          </span>
-          <Input
-            ref={inputRef}
-            value={newThreadName}
-            onChange={(e) => setNewThreadName(e.target.value)}
-            placeholder="Enter a new name..."
-          />
-        </Alert.AlertDialogDescription>
-        <Alert.AlertDialogFooter>
-          <Alert.AlertDialogCancel>Cancel</Alert.AlertDialogCancel>
-          <Alert.AlertDialogAction
-            onClick={() => {
-              if (!hoveredThread) return;
-              renameThread({
-                threadId: hoveredThread.id,
-                name: newThreadName,
-              });
-              setRenameModalOpen(false);
-              setNewThreadName("");
-            }}
-          >
-            Rename
-          </Alert.AlertDialogAction>
-        </Alert.AlertDialogFooter>
-      </Alert.AlertDialogContent>
-    </Alert.AlertDialog>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (!hoveredThread) return;
+            renameThread({
+              threadId: hoveredThread.id,
+              name: newThreadName,
+            });
+            setRenameModalOpen(false);
+            setNewThreadName("");
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>Rename Thread</DialogTitle>
+          </DialogHeader>
+          <DialogDescription className="flex flex-col gap-2 py-4">
+            <span className="text-muted-foreground">
+              Enter a new name for the thread.
+            </span>
+            <Input
+              ref={inputRef}
+              value={newThreadName}
+              onChange={(e) => setNewThreadName(e.target.value)}
+              placeholder="Enter a new name..."
+            />
+          </DialogDescription>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline">Cancel</Button>
+            </DialogClose>
+            <Button type="submit">Rename</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -60,7 +60,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-4rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 duration-200",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 supports-[backdrop-filter]:bg-background/50 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-xl border p-6 shadow-lg backdrop-blur-lg duration-200 sm:max-w-lg",
           className,
         )}
         {...props}


### PR DESCRIPTION
## Summary
- Switch rename flows for library files and threads from alert dialogs to standard dialogs with form submission, outline cancel actions, and better Enter-key behavior.
- Add a weekly newsletter preference section in user settings, including loader support and a toggle wired to the mail preference mutation.
- Introduce Upstash Redis-backed caching for current events, position holder, and weather tools, plus the new KV wrapper and env wiring.
- Update dialog styling for a larger, softer modal treatment and document the new Upstash dependency.

## Testing
- Not run
- Expected checks from repository instructions: `pnpm run lint`
- Expected checks from repository instructions: `pnpm run typecheck`
- Expected checks from repository instructions: `pnpm run format:fix`