### PR TITLE
Add X search and lookup tools for AI

### DIFF
--- a/packages/db/src/_generated/api.d.ts
+++ b/packages/db/src/_generated/api.d.ts
@@ -107,6 +107,12 @@ import type * as ai_tools_search_postition_holder from "../ai/tools/search/posti
 import type * as ai_tools_search_schemas from "../ai/tools/search/schemas.js";
 import type * as ai_tools_tool_helpers from "../ai/tools/tool_helpers.js";
 import type * as ai_tools_weather from "../ai/tools/weather.js";
+import type * as ai_tools_x_get_user_posts from "../ai/tools/x/get_user_posts.js";
+import type * as ai_tools_x_helpers from "../ai/tools/x/helpers.js";
+import type * as ai_tools_x_lookup_post from "../ai/tools/x/lookup_post.js";
+import type * as ai_tools_x_lookup_user from "../ai/tools/x/lookup_user.js";
+import type * as ai_tools_x_search_posts from "../ai/tools/x/search_posts.js";
+import type * as ai_tools_x_search_posts_archive from "../ai/tools/x/search_posts_archive.js";
 import type * as app_actions from "../app/actions.js";
 import type * as app_file_helpers from "../app/file_helpers.js";
 import type * as app_library from "../app/library.js";
@@ -245,6 +251,12 @@ declare const fullApi: ApiFromModules<{
   "ai/tools/search/schemas": typeof ai_tools_search_schemas;
   "ai/tools/tool_helpers": typeof ai_tools_tool_helpers;
   "ai/tools/weather": typeof ai_tools_weather;
+  "ai/tools/x/get_user_posts": typeof ai_tools_x_get_user_posts;
+  "ai/tools/x/helpers": typeof ai_tools_x_helpers;
+  "ai/tools/x/lookup_post": typeof ai_tools_x_lookup_post;
+  "ai/tools/x/lookup_user": typeof ai_tools_x_lookup_user;
+  "ai/tools/x/search_posts": typeof ai_tools_x_search_posts;
+  "ai/tools/x/search_posts_archive": typeof ai_tools_x_search_posts_archive;
   "app/actions": typeof app_actions;
   "app/file_helpers": typeof app_file_helpers;
   "app/library": typeof app_library;

--- a/packages/db/src/ai/tools/index.ts
+++ b/packages/db/src/ai/tools/index.ts
@@ -4,6 +4,11 @@ import { editImage, generateImage, initImage } from "./image";
 import { currentEvents } from "./search/current_events";
 import { positionHolder } from "./search/postition_holder";
 import { weather } from "./weather";
+import { getXUserPosts } from "./x/get_user_posts";
+import { lookupXPost } from "./x/lookup_post";
+import { lookupXUser } from "./x/lookup_user";
+import { searchXPosts } from "./x/search_posts";
+import { searchXPostsArchive } from "./x/search_posts_archive";
 
 export const tools = {
   dateTime,
@@ -14,4 +19,9 @@ export const tools = {
   generateImage,
   initImage,
   editImage,
+  searchXPosts,
+  searchXPostsArchive,
+  lookupXPost,
+  lookupXUser,
+  getXUserPosts,
 };

--- a/packages/db/src/ai/tools/x/get_user_posts.ts
+++ b/packages/db/src/ai/tools/x/get_user_posts.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+
+import { createTool } from "../../../agent/tools";
+import { tryCatch } from "../../../lib/utils";
+import {
+  formatSearchResults,
+  getUserTimeline,
+  logXApiCost,
+  lookupUser,
+} from "./helpers";
+
+export const getXUserPosts = createTool({
+  description: `
+  Get recent posts from a specific user on X (formerly Twitter).
+
+  Provide the username (handle) of the user. The tool resolves the username to
+  a user ID automatically.
+
+  You can optionally exclude retweets and/or replies to only see the user's
+  original posts.
+
+  Returns a list of posts with text, engagement metrics, and URLs.
+
+  IMPORTANT: Always use the smallest max_results that satisfies the request. The
+  X API charges per post read, so fewer results = lower cost. Default to 10 and
+  only increase if the user explicitly asks for more.
+  `,
+  inputSchema: z.object({
+    username: z
+      .string()
+      .min(1)
+      .max(20)
+      .describe("The X username/handle without the @ symbol"),
+    max_results: z
+      .number()
+      .min(5)
+      .max(20)
+      .default(10)
+      .describe(
+        "Number of posts to return (5-20). Keep low to minimize API cost.",
+      ),
+    exclude_retweets: z
+      .boolean()
+      .default(true)
+      .describe("Whether to exclude retweets from results"),
+    exclude_replies: z
+      .boolean()
+      .default(false)
+      .describe("Whether to exclude replies from results"),
+  }),
+  execute: async (ctx, args) => {
+    const username = args.username.replace(/^@/, "");
+
+    const { data: userResult, error: userError } = await tryCatch(
+      lookupUser(username),
+    );
+    if (userError) {
+      console.error("Error looking up X user for timeline", userError);
+      return null;
+    }
+
+    const { data, error } = await tryCatch(
+      getUserTimeline(
+        userResult.data.id,
+        args.max_results,
+        args.exclude_retweets,
+        args.exclude_replies,
+      ),
+    );
+    if (error) {
+      console.error("Error fetching X user timeline", error);
+      return null;
+    }
+
+    if (ctx.userId) {
+      await logXApiCost(
+        ctx,
+        {
+          posts: data.data?.length ?? 0,
+          users: 1,
+        },
+        ctx.userId,
+      );
+    }
+
+    return {
+      user: {
+        name: userResult.data.name,
+        username: userResult.data.username,
+        profile_url: `https://x.com/${userResult.data.username}`,
+      },
+      ...formatSearchResults(data),
+    };
+  },
+});

--- a/packages/db/src/ai/tools/x/helpers.ts
+++ b/packages/db/src/ai/tools/x/helpers.ts
@@ -1,0 +1,295 @@
+import { z } from "zod";
+
+import type { ToolCtx } from "../../../agent/tools";
+import { internal } from "../../../_generated/api";
+import { env } from "../../../convex.env";
+
+const BASE_URL = "https://api.x.com/2";
+
+const TWEET_FIELDS = [
+  "author_id",
+  "created_at",
+  "public_metrics",
+  "conversation_id",
+  "lang",
+  "entities",
+  "referenced_tweets",
+].join(",");
+
+const USER_FIELDS = [
+  "created_at",
+  "description",
+  "profile_image_url",
+  "public_metrics",
+  "location",
+  "url",
+  "verified",
+  "verified_type",
+].join(",");
+
+const EXPANSIONS = ["author_id", "referenced_tweets.id"].join(",");
+
+const xUserSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  username: z.string(),
+  created_at: z.string().optional(),
+  description: z.string().optional(),
+  profile_image_url: z.string().optional(),
+  public_metrics: z
+    .object({
+      followers_count: z.number(),
+      following_count: z.number(),
+      tweet_count: z.number(),
+      listed_count: z.number(),
+    })
+    .optional(),
+  location: z.string().optional(),
+  url: z.string().optional(),
+  verified: z.boolean().optional(),
+  verified_type: z.string().optional(),
+});
+
+const xTweetSchema = z.object({
+  id: z.string(),
+  text: z.string(),
+  author_id: z.string().optional(),
+  created_at: z.string().optional(),
+  public_metrics: z
+    .object({
+      retweet_count: z.number(),
+      reply_count: z.number(),
+      like_count: z.number(),
+      quote_count: z.number(),
+      bookmark_count: z.number().optional(),
+      impression_count: z.number().optional(),
+    })
+    .optional(),
+  conversation_id: z.string().optional(),
+  lang: z.string().optional(),
+  entities: z.unknown().optional(),
+  referenced_tweets: z
+    .array(
+      z.object({
+        type: z.enum(["retweeted", "quoted", "replied_to"]),
+        id: z.string(),
+      }),
+    )
+    .optional(),
+});
+
+const xSearchResponseSchema = z.object({
+  data: z.array(xTweetSchema).optional(),
+  includes: z
+    .object({
+      users: z.array(xUserSchema).optional(),
+      tweets: z.array(xTweetSchema).optional(),
+    })
+    .optional(),
+  meta: z
+    .object({
+      newest_id: z.string().optional(),
+      oldest_id: z.string().optional(),
+      result_count: z.number(),
+      next_token: z.string().optional(),
+    })
+    .optional(),
+});
+
+const xUserLookupResponseSchema = z.object({
+  data: xUserSchema,
+});
+
+const xTweetLookupResponseSchema = z.object({
+  data: xTweetSchema,
+  includes: z
+    .object({
+      users: z.array(xUserSchema).optional(),
+      tweets: z.array(xTweetSchema).optional(),
+    })
+    .optional(),
+});
+
+const xUserTimelineResponseSchema = z.object({
+  data: z.array(xTweetSchema).optional(),
+  includes: z
+    .object({
+      users: z.array(xUserSchema).optional(),
+      tweets: z.array(xTweetSchema).optional(),
+    })
+    .optional(),
+  meta: z
+    .object({
+      newest_id: z.string().optional(),
+      oldest_id: z.string().optional(),
+      result_count: z.number(),
+      next_token: z.string().optional(),
+    })
+    .optional(),
+});
+
+export type XUser = z.infer<typeof xUserSchema>;
+export type XTweet = z.infer<typeof xTweetSchema>;
+
+async function xFetch(url: string) {
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${env.X_BEARER_TOKEN}`,
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `X API request failed: ${res.status.toString()} ${res.statusText} — ${body}`,
+    );
+  }
+  return z.unknown().parse(await res.json());
+}
+
+export async function searchRecentPosts(query: string, maxResults: number) {
+  const params = new URLSearchParams({
+    query,
+    max_results: maxResults.toString(),
+    "tweet.fields": TWEET_FIELDS,
+    "user.fields": USER_FIELDS,
+    expansions: EXPANSIONS,
+  });
+  const data = await xFetch(
+    `${BASE_URL}/tweets/search/recent?${params.toString()}`,
+  );
+  return xSearchResponseSchema.parse(data);
+}
+
+export async function searchAllPosts(
+  query: string,
+  maxResults: number,
+  startTime?: string,
+  endTime?: string,
+) {
+  const params = new URLSearchParams({
+    query,
+    max_results: maxResults.toString(),
+    "tweet.fields": TWEET_FIELDS,
+    "user.fields": USER_FIELDS,
+    expansions: EXPANSIONS,
+  });
+  if (startTime) params.set("start_time", startTime);
+  if (endTime) params.set("end_time", endTime);
+  const data = await xFetch(
+    `${BASE_URL}/tweets/search/all?${params.toString()}`,
+  );
+  return xSearchResponseSchema.parse(data);
+}
+
+export async function lookupUser(username: string) {
+  const params = new URLSearchParams({
+    "user.fields": USER_FIELDS,
+  });
+  const data = await xFetch(
+    `${BASE_URL}/users/by/username/${encodeURIComponent(username)}?${params.toString()}`,
+  );
+  return xUserLookupResponseSchema.parse(data);
+}
+
+export async function lookupPost(tweetId: string) {
+  const params = new URLSearchParams({
+    "tweet.fields": TWEET_FIELDS,
+    "user.fields": USER_FIELDS,
+    expansions: [EXPANSIONS, "attachments.media_keys"].join(","),
+  });
+  const data = await xFetch(
+    `${BASE_URL}/tweets/${encodeURIComponent(tweetId)}?${params.toString()}`,
+  );
+  return xTweetLookupResponseSchema.parse(data);
+}
+
+export async function getUserTimeline(
+  userId: string,
+  maxResults: number,
+  excludeRetweets: boolean,
+  excludeReplies: boolean,
+) {
+  const params = new URLSearchParams({
+    max_results: maxResults.toString(),
+    "tweet.fields": TWEET_FIELDS,
+    "user.fields": USER_FIELDS,
+    expansions: EXPANSIONS,
+  });
+  const excludes = [
+    excludeRetweets && "retweets",
+    excludeReplies && "replies",
+  ].filter(Boolean);
+  if (excludes.length > 0) params.set("exclude", excludes.join(","));
+  const data = await xFetch(
+    `${BASE_URL}/users/${encodeURIComponent(userId)}/tweets?${params.toString()}`,
+  );
+  return xUserTimelineResponseSchema.parse(data);
+}
+
+function formatTweet(tweet: XTweet, users?: XUser[]) {
+  const author = users?.find((u) => u.id === tweet.author_id);
+  const metrics = tweet.public_metrics;
+  return {
+    id: tweet.id,
+    text: tweet.text,
+    author: author
+      ? { name: author.name, username: author.username }
+      : { id: tweet.author_id },
+    created_at: tweet.created_at,
+    metrics: metrics
+      ? {
+          likes: metrics.like_count,
+          retweets: metrics.retweet_count,
+          replies: metrics.reply_count,
+          quotes: metrics.quote_count,
+        }
+      : undefined,
+    referenced_tweets: tweet.referenced_tweets,
+    url: author
+      ? `https://x.com/${author.username}/status/${tweet.id}`
+      : undefined,
+  };
+}
+
+export function formatSearchResults(
+  response: z.infer<typeof xSearchResponseSchema>,
+) {
+  if (!response.data || response.data.length === 0) {
+    return { posts: [], result_count: 0 };
+  }
+  const users = response.includes?.users;
+  return {
+    posts: response.data.map((tweet) => formatTweet(tweet, users)),
+    result_count: response.meta?.result_count ?? response.data.length,
+    next_token: response.meta?.next_token,
+  };
+}
+
+export function formatTweetResult(
+  response: z.infer<typeof xTweetLookupResponseSchema>,
+) {
+  const users = response.includes?.users;
+  return formatTweet(response.data, users);
+}
+
+// Pricing: https://docs.x.com/x-api/getting-started/pricing
+// Update these values when X changes their pay-per-use rates.
+export const X_API_PRICING = {
+  postRead: 0.005,
+  userRead: 0.01,
+} as const;
+
+export async function logXApiCost(
+  ctx: ToolCtx,
+  resources: { posts?: number; users?: number },
+  userId: string,
+) {
+  const cost =
+    (resources.posts ?? 0) * X_API_PRICING.postRead +
+    (resources.users ?? 0) * X_API_PRICING.userRead;
+  await ctx.runMutation(internal.user.usage.log, {
+    userId,
+    type: "tool_call",
+    cost,
+  });
+}

--- a/packages/db/src/ai/tools/x/lookup_post.ts
+++ b/packages/db/src/ai/tools/x/lookup_post.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+import { createTool } from "../../../agent/tools";
+import { tryCatch } from "../../../lib/utils";
+import { formatTweetResult, logXApiCost, lookupPost } from "./helpers";
+
+export const lookupXPost = createTool({
+  description: `
+  Look up a specific post on X (formerly Twitter) by its ID or URL. Use this when
+  the user shares an X post URL or references a specific post ID and wants details
+  about it.
+
+  Accepts either a numeric post ID or a full X URL like
+  https://x.com/username/status/1234567890.
+
+  Returns the post text, author info, engagement metrics, and creation time.
+  `,
+  inputSchema: z.object({
+    post_id: z
+      .string()
+      .min(1)
+      .describe(
+        "The numeric post ID, or a full X/Twitter URL (the ID will be extracted automatically)",
+      ),
+  }),
+  execute: async (ctx, args) => {
+    const id = extractPostId(args.post_id);
+
+    const { data, error } = await tryCatch(lookupPost(id));
+    if (error) {
+      console.error("Error looking up X post", error);
+      return null;
+    }
+
+    if (ctx.userId) {
+      await logXApiCost(ctx, { posts: 1 }, ctx.userId);
+    }
+
+    return formatTweetResult(data);
+  },
+});
+
+function extractPostId(input: string) {
+  const urlMatch = /\/status\/(\d+)/.exec(input);
+  if (urlMatch?.[1]) return urlMatch[1];
+  return input;
+}

--- a/packages/db/src/ai/tools/x/lookup_user.ts
+++ b/packages/db/src/ai/tools/x/lookup_user.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+import { createTool } from "../../../agent/tools";
+import { tryCatch } from "../../../lib/utils";
+import { logXApiCost, lookupUser } from "./helpers";
+
+export const lookupXUser = createTool({
+  description: `
+  Look up a user profile on X (formerly Twitter) by their username/handle.
+
+  Returns the user's display name, bio/description, profile image, follower and
+  following counts, post count, location, website URL, and verification status.
+
+  Use this when the user asks about a specific X account or when you need to
+  resolve a username to a user ID (required for the user timeline tool).
+  `,
+  inputSchema: z.object({
+    username: z
+      .string()
+      .min(1)
+      .max(15)
+      .describe(
+        "The X username/handle without the @ symbol (e.g. 'elonmusk' not '@elonmusk')",
+      ),
+  }),
+  execute: async (ctx, args) => {
+    const username = args.username.replace(/^@/, "");
+
+    const { data, error } = await tryCatch(lookupUser(username));
+    if (error) {
+      console.error("Error looking up X user", error);
+      return null;
+    }
+
+    if (ctx.userId) {
+      await logXApiCost(ctx, { users: 1 }, ctx.userId);
+    }
+
+    const user = data.data;
+    return {
+      id: user.id,
+      name: user.name,
+      username: user.username,
+      description: user.description,
+      profile_image_url: user.profile_image_url,
+      metrics: user.public_metrics,
+      location: user.location,
+      url: user.url,
+      verified: user.verified,
+      verified_type: user.verified_type,
+      created_at: user.created_at,
+      profile_url: `https://x.com/${user.username}`,
+    };
+  },
+});

--- a/packages/db/src/ai/tools/x/search_posts.ts
+++ b/packages/db/src/ai/tools/x/search_posts.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+
+import { createTool } from "../../../agent/tools";
+import { tryCatch } from "../../../lib/utils";
+import { formatSearchResults, logXApiCost, searchRecentPosts } from "./helpers";
+
+export const searchXPosts = createTool({
+  description: `
+  Search for posts on X (formerly Twitter) from the last 7 days.
+
+  Supports the full X search query syntax including operators:
+  - from:username — posts from a specific user
+  - to:username — replies to a specific user
+  - #hashtag — posts with a specific hashtag
+  - "exact phrase" — exact phrase match
+  - has:media, has:images, has:links — filter by content type
+  - lang:en — filter by language (BCP 47 codes)
+  - is:reply, is:retweet, is:quote — filter by post type
+  - -keyword — exclude a keyword
+  - Combine operators with spaces (AND) or OR
+
+  Returns a list of posts with author info, text, engagement metrics, and URLs.
+
+  IMPORTANT: Always use the smallest max_results that satisfies the request. The
+  X API charges per post read, so fewer results = lower cost. Default to 10 and
+  only increase if the user explicitly asks for more.
+  `,
+  inputSchema: z.object({
+    query: z
+      .string()
+      .min(1)
+      .max(512)
+      .describe(
+        "Search query using X search syntax. Can include operators like from:, #hashtag, has:media, lang:, etc.",
+      ),
+    max_results: z
+      .number()
+      .min(10)
+      .max(20)
+      .default(10)
+      .describe(
+        "Number of posts to return (10-20). Keep low to minimize API cost.",
+      ),
+  }),
+  execute: async (ctx, args) => {
+    const { data, error } = await tryCatch(
+      searchRecentPosts(args.query, args.max_results),
+    );
+    if (error) {
+      console.error("Error searching X posts", error);
+      return null;
+    }
+
+    if (ctx.userId) {
+      await logXApiCost(
+        ctx,
+        {
+          posts: Math.max(data.data?.length ?? 0, 1),
+          users: data.includes?.users?.length ?? 0,
+        },
+        ctx.userId,
+      );
+    }
+
+    return formatSearchResults(data);
+  },
+});

--- a/packages/db/src/ai/tools/x/search_posts_archive.ts
+++ b/packages/db/src/ai/tools/x/search_posts_archive.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+
+import { createTool } from "../../../agent/tools";
+import { tryCatch } from "../../../lib/utils";
+import { formatSearchResults, logXApiCost, searchAllPosts } from "./helpers";
+
+export const searchXPostsArchive = createTool({
+  description: `
+  Search the full historical archive of posts on X (formerly Twitter), going back
+  to March 2006. Use this when the user is looking for old posts or posts outside
+  the last 7 days.
+
+  Supports the same query syntax as the recent search tool:
+  - from:username — posts from a specific user
+  - to:username — replies to a specific user
+  - #hashtag — posts with a specific hashtag
+  - "exact phrase" — exact phrase match
+  - has:media, has:images, has:links — filter by content type
+  - lang:en — filter by language (BCP 47 codes)
+  - is:reply, is:retweet, is:quote — filter by post type
+  - -keyword — exclude a keyword
+
+  Optionally filter by date range using start_time and end_time in ISO 8601 format.
+
+  Returns a list of posts with author info, text, engagement metrics, and URLs.
+
+  IMPORTANT: Always use the smallest max_results that satisfies the request. The
+  X API charges per post read, so fewer results = lower cost. Default to 10 and
+  only increase if the user explicitly asks for more.
+  `,
+  inputSchema: z.object({
+    query: z
+      .string()
+      .min(1)
+      .max(1024)
+      .describe(
+        "Search query using X search syntax. Can include operators like from:, #hashtag, has:media, lang:, etc.",
+      ),
+    max_results: z
+      .number()
+      .min(10)
+      .max(20)
+      .default(10)
+      .describe(
+        "Number of posts to return (10-20). Keep low to minimize API cost.",
+      ),
+    start_time: z
+      .string()
+      .optional()
+      .describe(
+        "Start of time range in ISO 8601 format (e.g. 2023-01-01T00:00:00Z). Only posts after this time are returned.",
+      ),
+    end_time: z
+      .string()
+      .optional()
+      .describe(
+        "End of time range in ISO 8601 format (e.g. 2024-06-01T00:00:00Z). Only posts before this time are returned.",
+      ),
+  }),
+  execute: async (ctx, args) => {
+    const { data, error } = await tryCatch(
+      searchAllPosts(
+        args.query,
+        args.max_results,
+        args.start_time,
+        args.end_time,
+      ),
+    );
+    if (error) {
+      console.error("Error searching X post archive", error);
+      return null;
+    }
+
+    if (ctx.userId) {
+      await logXApiCost(
+        ctx,
+        {
+          posts: Math.max(data.data?.length ?? 0, 1),
+          users: data.includes?.users?.length ?? 0,
+        },
+        ctx.userId,
+      );
+    }
+
+    return formatSearchResults(data);
+  },
+});

--- a/packages/db/src/convex.env.ts
+++ b/packages/db/src/convex.env.ts
@@ -22,4 +22,5 @@ export const env = createEnv({
   OPENROUTER_API_KEY: v.string(),
   AI_GATEWAY_API_KEY: v.string(),
   NEXT_CONVEX_INTERNAL_KEY: v.string(),
+  X_BEARER_TOKEN: v.string(),
 });


### PR DESCRIPTION
## Summary
- Added new X tool integrations for recent search, archive search, user lookup, post lookup, and user timeline retrieval.
- Centralized X API request, response validation, formatting, and usage-cost logging helpers.
- Wired the new tools into the AI tool registry and added the required `X_BEARER_TOKEN` env var.

## Testing
- Not run (PR description only).
- Recommended checks after merge: `pnpm run lint`.
- Recommended checks after merge: `pnpm run typecheck`.
- Recommended checks after merge: `pnpm run format:fix` if lint/typecheck pass.