### PR TITLE
Add webpage content retrieval tool

### DIFF
--- a/packages/db/src/_generated/api.d.ts
+++ b/packages/db/src/_generated/api.d.ts
@@ -102,6 +102,7 @@ import type * as ai_tools_image_index from "../ai/tools/image/index.js";
 import type * as ai_tools_image_types from "../ai/tools/image/types.js";
 import type * as ai_tools_index from "../ai/tools/index.js";
 import type * as ai_tools_search_current_events from "../ai/tools/search/current_events.js";
+import type * as ai_tools_search_get_page_contents from "../ai/tools/search/get_page_contents.js";
 import type * as ai_tools_search_index from "../ai/tools/search/index.js";
 import type * as ai_tools_search_postition_holder from "../ai/tools/search/postition_holder.js";
 import type * as ai_tools_search_schemas from "../ai/tools/search/schemas.js";
@@ -246,6 +247,7 @@ declare const fullApi: ApiFromModules<{
   "ai/tools/image/types": typeof ai_tools_image_types;
   "ai/tools/index": typeof ai_tools_index;
   "ai/tools/search/current_events": typeof ai_tools_search_current_events;
+  "ai/tools/search/get_page_contents": typeof ai_tools_search_get_page_contents;
   "ai/tools/search/index": typeof ai_tools_search_index;
   "ai/tools/search/postition_holder": typeof ai_tools_search_postition_holder;
   "ai/tools/search/schemas": typeof ai_tools_search_schemas;

--- a/packages/db/src/ai/tools/index.ts
+++ b/packages/db/src/ai/tools/index.ts
@@ -2,6 +2,7 @@ import { dateTime } from "./date_time";
 import { analyzeFiles } from "./files";
 import { editImage, generateImage, initImage } from "./image";
 import { currentEvents } from "./search/current_events";
+import { getPageContents } from "./search/get_page_contents";
 import { positionHolder } from "./search/postition_holder";
 import { weather } from "./weather";
 import { getXUserPosts } from "./x/get_user_posts";
@@ -15,6 +16,7 @@ export const tools = {
   currentEvents,
   weather,
   positionHolder,
+  getPageContents,
   analyzeFiles,
   generateImage,
   initImage,

--- a/packages/db/src/ai/tools/search/get_page_contents.ts
+++ b/packages/db/src/ai/tools/search/get_page_contents.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+import { createTool } from "../../../agent/tools";
+import { tryCatch } from "../../../lib/utils";
+import { exaGetContents, logContentsCost } from "../tool_helpers";
+
+export const getPageContents = createTool({
+  description: `
+  Retrieves the text content of a webpage given its URL.
+
+  Use this tool when the user provides a link and wants to know what's on the
+  page, or when you need to read the contents of a specific URL to answer a
+  question.
+
+  Returns an object with:
+  - url: the url that was fetched
+  - title: the page title
+  - content: the extracted text content of the page
+  `,
+  inputSchema: z.object({
+    url: z
+      .string()
+      .url()
+      .describe("The full URL of the webpage to retrieve contents from"),
+  }),
+  execute: async (ctx, args) => {
+    const { data: response, error: responseError } = await tryCatch(
+      exaGetContents(args.url),
+    );
+    if (responseError) {
+      console.error("Error during get page contents tool call", responseError);
+      return null;
+    }
+
+    if (ctx.userId) {
+      await logContentsCost(ctx, 1, ctx.userId);
+    }
+
+    const result = response.results[0];
+    return {
+      url: result.url,
+      title: result.title,
+      content: result.text,
+    };
+  },
+});

--- a/packages/db/src/ai/tools/search/index.ts
+++ b/packages/db/src/ai/tools/search/index.ts
@@ -1,3 +1,4 @@
 export * from "./schemas";
 export * from "./current_events";
 export * from "./postition_holder";
+export * from "./get_page_contents";

--- a/packages/db/src/ai/tools/tool_helpers.ts
+++ b/packages/db/src/ai/tools/tool_helpers.ts
@@ -61,3 +61,49 @@ export async function logSearchCost(
     cost: totalCost,
   });
 }
+
+const exaContentsResponseSchema = z.object({
+  results: z
+    .array(
+      z.object({
+        url: z.string(),
+        title: z.string().nullable(),
+        text: z.string(),
+      }),
+    )
+    .nonempty(),
+});
+
+export async function exaGetContents(url: string) {
+  const res = await fetch("https://api.exa.ai/contents", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": env.EXA_API_KEY,
+    },
+    body: JSON.stringify({
+      urls: [url],
+      text: { maxCharacters: 10000 },
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Exa contents failed: ${res.status.toString()} ${res.statusText}`,
+    );
+  }
+  return exaContentsResponseSchema.parse(await res.json());
+}
+
+export async function logContentsCost(
+  ctx: ToolCtx,
+  numPages: number,
+  userId: string,
+) {
+  const costPerPage = 0.001; // $1 / 1000 pages
+  const totalCost = numPages * costPerPage;
+  await ctx.runMutation(internal.user.usage.log, {
+    userId: userId,
+    type: "tool_call",
+    cost: totalCost,
+  });
+}


### PR DESCRIPTION
## Summary
- Added a new `getPageContents` AI tool for fetching and extracting text from a webpage URL.
- Wired the tool into the search tool exports and the main AI tools registry.
- Added Exa contents API helper logic plus usage-cost logging for page fetches.

## Testing
- Not run (PR content only).
- Suggested checks: `pnpm run lint`
- Suggested checks: `pnpm run typecheck`
- Suggested checks: `pnpm run format:fix`